### PR TITLE
Fix SteamVR driver bug in the new motion smoothing beta

### DIFF
--- a/driver_vrinputemulator/src/hooks/IVRServerDriverHost004Hooks.cpp
+++ b/driver_vrinputemulator/src/hooks/IVRServerDriverHost004Hooks.cpp
@@ -75,6 +75,11 @@ void IVRServerDriverHost004Hooks::trackedDeviceAxisUpdatedOrig(void * _this, uin
 
 
 bool IVRServerDriverHost004Hooks::_trackedDeviceAdded(void* _this, const char *pchDeviceSerialNumber, vr::ETrackedDeviceClass eDeviceClass, void *pDriver) {
+	char *sn = (char*)pchDeviceSerialNumber;
+	if ((sn >= (char*)0 && sn < (char*)0xff) || eDeviceClass < -1 || eDeviceClass > 255 ) {
+		// SteamVR Vive driver bug, it's calling this function with random garbage
+		return trackedDeviceAddedHook.origFunc(_this, sn, eDeviceClass, pDriver);
+	}
 	LOG(TRACE) << "IVRServerDriverHost004Hooks::_trackedDeviceAdded(" << _this << ", " << pchDeviceSerialNumber << ", " << eDeviceClass << ", " << pDriver << ")";
 	serverDriver->hooksTrackedDeviceAdded(_this, 4, pchDeviceSerialNumber, eDeviceClass, pDriver);
 	auto retval = trackedDeviceAddedHook.origFunc(_this, pchDeviceSerialNumber, eDeviceClass, pDriver);

--- a/driver_vrinputemulator/src/hooks/IVRServerDriverHost004Hooks.cpp
+++ b/driver_vrinputemulator/src/hooks/IVRServerDriverHost004Hooks.cpp
@@ -76,9 +76,10 @@ void IVRServerDriverHost004Hooks::trackedDeviceAxisUpdatedOrig(void * _this, uin
 
 bool IVRServerDriverHost004Hooks::_trackedDeviceAdded(void* _this, const char *pchDeviceSerialNumber, vr::ETrackedDeviceClass eDeviceClass, void *pDriver) {
 	char *sn = (char*)pchDeviceSerialNumber;
-	if ((sn >= (char*)0 && sn < (char*)0xff) || eDeviceClass < -1 || eDeviceClass > 255 ) {
+	if ((sn >= (char*)0 && sn < (char*)0xff) || eDeviceClass < 0 || eDeviceClass > vr::ETrackedDeviceClass::TrackedDeviceClass_DisplayRedirect ) {
 		// SteamVR Vive driver bug, it's calling this function with random garbage
-		return trackedDeviceAddedHook.origFunc(_this, sn, eDeviceClass, pDriver);
+		LOG(ERROR) << "Not running _trackedDeviceAdded because of SteamVR driver bug.";
+		return false;
 	}
 	LOG(TRACE) << "IVRServerDriverHost004Hooks::_trackedDeviceAdded(" << _this << ", " << pchDeviceSerialNumber << ", " << eDeviceClass << ", " << pDriver << ")";
 	serverDriver->hooksTrackedDeviceAdded(_this, 4, pchDeviceSerialNumber, eDeviceClass, pDriver);


### PR DESCRIPTION
The driver for Vive implements both IVRServerDriverHost_004 and IVRServerDriverHost_005. Since the Vive driver is always included with SteamVR, it makes no sense to have more than one interface version. The v4 sends garbage and made the driver crash, so we're just ignoring that call when we get a string with a very small pointer, or a device class that is not a small positive number.

This issue still appears to be present on SteamVR 1.2.7